### PR TITLE
fix makeent

### DIFF
--- a/redis-store.js
+++ b/redis-store.js
@@ -419,6 +419,7 @@ var makeent = function(ent, row, objMap) {
   var entp;
   var fields;
 
+  if (!objMap) objMap = { map:{} };
   row = JSON.parse(row);
   fields = _.keys(row);
 


### PR DESCRIPTION
I have noticed weird behaviour where out of 15 runs, 6-9 of them produced an entity init error. It's difficult to reproduce this problem as it occured randomly.

Adding this line fixed it all. Using _.isUndefined and _.isNull did not work, so I have used the good old negation.

What do you think?